### PR TITLE
Adding some Android Studio file projects to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,13 @@ proguard/
 
 # Log Files
 *.log
+
+# Android Studio
+**/local.properties
+**/.idea/workspace.xml
+**/.idea/libraries
+captures
+
+# Others
+.DS_Store
+


### PR DESCRIPTION
Adding the Android Studio files to .gitignore to avoid files to be miscommitted.

Signed-off-by: Eduardo Carrara ecarrara.araujo@gmail.com
